### PR TITLE
Trim list of orgs

### DIFF
--- a/loaderio-variables.json
+++ b/loaderio-variables.json
@@ -4,14 +4,9 @@
         {
             "names": ["org_id", "org_slug"],
             "values": [
-                ["1767", "berniesanders"],
-                ["1316", "elizabethwarren"],
-                ["1297", "peteforamerica"],
                 ["1393", "joebiden"],
                 ["159", "swingleft"],
-                ["1286", "needtoimpeach"],
-                ["206", "crooked"],
-                ["9", "dnc"]
+                ["206", "crooked"]
             ]
         },
         {


### PR DESCRIPTION
Remove DNC since it redirects away from load.mobilize.us.

Remove other orgs that no longer exist.