### PR TITLE
Update orgs to current ones

### DIFF
--- a/loaderio-variables.json
+++ b/loaderio-variables.json
@@ -4,14 +4,16 @@
         {
             "names": ["org_id", "org_slug"],
             "values": [
-                ["1767", "berniesanders"],
-                ["1316", "elizabethwarren"],
-                ["1297", "peteforamerica"],
-                ["1393", "joebiden"],
-                ["159", "swingleft"],
-                ["1286", "needtoimpeach"],
-                ["206", "crooked"],
-                ["9", "dnc"]
+                ["2425", "sunrisemovement"],
+                ["1545", "mecklenburgcountydems"],
+                ["1914", "nsvrc"],
+                ["2578", "wakedems"],
+                ["6150", "yangforny"],
+                ["2220", "sjpd"],
+                ["7491", "dianne4nyc"],
+                ["6208", "jennifercarrollfoy"],
+                ["6176", "stringerformayor"],
+                ["1987", "ourrevolution"]
             ]
         },
         {


### PR DESCRIPTION
The previous org list skewed heavily to presidentials and presidential-race related orgs. This PR updates the org set to feature orgs with a large number of current events (created since Feb. '21)